### PR TITLE
変更：moisture ⇒ vapour

### DIFF
--- a/vapour.ipynb
+++ b/vapour.ipynb
@@ -23,7 +23,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# 温度・水分の状態を保持するモジュール"
+    "# 水蒸気の温度・水分の状態を保持するモジュール"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 水分化学ポテンシャルを基準とした水分状態  "
    ]
   },
   {
@@ -42,33 +49,49 @@
     "    \n",
     "    def set_temp(self, temp):\n",
     "        self.temp = temp\n",
-    "    \n",
-    "    def get_temp(self):\n",
-    "        return self.temp\n",
     "\n",
     "    # miu\n",
     "    \n",
     "    def set_miu(self, miu):\n",
     "        self.miu = miu\n",
+    "    \n",
+    "    def set_miu_from_pv(self, pv):\n",
+    "        self.miu = mc.convertPV2Miu(self.temp, pv)        \n",
     "        \n",
-    "    def get_miu(self):\n",
-    "        return self.miu\n",
+    "    def set_miu_from_RH(self, rh):\n",
+    "        self.miu = mc.convertRH2Miu(self.temp, rh)        \n",
     "    \n",
     "    # pv\n",
     "    \n",
-    "    def set_pv(self, pv):\n",
-    "        self.miu = mc.convertPV2Miu(self.temp, pv)\n",
-    "    \n",
-    "    def get_pv(self):\n",
-    "        return mc.convertMiu2Pv(self.temp, self.miu)\n",
+    "    def set_pv(self):\n",
+    "        self.pv = mc.convertMiu2Pv(self.temp, self.miu)\n",
     "    \n",
     "    # RH\n",
     "    \n",
-    "    def set_RH(self, rh):\n",
-    "        self.miu = mc.convertRH2Miu(self.temp, rh)\n",
-    "        \n",
-    "    def get_RH(self):\n",
-    "        return mc.convertMiu2RH(self.temp, self.miu)    "
+    "    def set_RH(self):\n",
+    "        self.rh = mc.convertMiu2RH(self.temp, self.miu)  \n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 相対湿度を基準とした水分状態"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 水蒸気圧を基準とした水分状態"
    ]
   },
   {


### PR DESCRIPTION
"#　v1 = MiuBasedMoisture(xx,xx)
x = v1.rh
とか
v2 = RHBasedMoisture(xx,xx)
x = v2.rh
とかで、変数の生成の部分だけ適切なものを選べば、それ以降のコードを共有できるイメージです。

こちらの点踏まえまして少し変更を行いました。

クラス内関数として
def get_rh(self):
  return .....
として呼び出すよりもクラス内変数として
self.rh
として定義したほうが計算上便利かと思いました。