### PR TITLE
修正：熱流の計算方法をv1からv3までの方法で分類

### DIFF
--- a/Flux.ipynb
+++ b/Flux.ipynb
@@ -16,7 +16,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -28,7 +28,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### フーリエの熱伝導  \n",
+    "### 熱伝導（フーリエの法則）  \n",
     "定義：$\\dot q = -\\lambda\\nabla・T$  \n",
     "$\\dot q$：単位時間当たりの熱流量の密度[W/m2]  \n",
     "$\\lambda$：熱伝導率[W/mK]  \n",
@@ -36,24 +36,81 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 6,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "def heatConduction( lam, dtemp, dx2 ):\n",
-    "    return lam * dtemp / dx2"
+    "#### 差分化その1：$\\dot q = -\\lambda_{ave.}\\frac{T_{l+1}-T_{l}}{dx_{l+1}+dx_{l}}$  \n",
+    "$\\lambda_{ave.}$：平均の熱伝導率  \n",
+    "$l, l+1$：ある点のセル・隣接する点のセル  \n",
+    "$dx$：セルの質点からセル境界までの距離"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 気相水分流（水蒸気圧勾配・固体内）  \n",
-    "定義：$J_v = -\\lambda^{'}_{p}\\nabla・P_v$  \n",
-    "$J_v$：気相水分流量[kg/m2s]  \n",
-    "$\\lambda^{'}_{p}$：水蒸気圧勾配に関する気相水分伝導率[kg/msPa]  \n",
-    "$P_v$：水蒸気圧[Pa]  "
+    "物性値の調和平均：\n",
+    "$\\lambda_{ave}=\\frac{\\lambda_{l+1} dx_{l+1} + \\lambda_{l} dx_{l} }{ dx_{l+1} + dx_{l} }$  \n",
+    "物性値を材料の長さに応じて調和平均化する。熱伝導率の差が小さい時は問題ないが、差が大きくなるとその2のように熱抵抗の和として考えるのが妥当"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def mean_average( val_mns, val_pls, len_mns, len_pls ):\n",
+    "    return ( val_mns * len_mns + val_pls * len_pls ) / ( len_mns + len_pls )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def heat_conduction_v1( lamL1, lamL, tempL1, tempL, dxL1, dxL ):\n",
+    "    lamAve = mean_average( val_mns = lamL, val_pls = lamL1, len_mns = dxL, len_pls = dxL1 )\n",
+    "    return - lamAve * ( tempL1 - tempL ) / ( dxL1 + dxL )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "54.99999999999999"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "#　使用例\n",
+    "heat_conduction_v1( 0.1, 1.0, 20.0, 22.0, 0.01, 0.01 )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### 差分化その2：$\\dot q = -K(T_{l+1}-T_{l})$  \n",
+    "$K$：熱貫流率[W/K]  \n",
+    "一般的にはこちらを採用。異種材料間の熱の移動は熱抵抗値の和として計算。"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "熱貫流率：\n",
+    "$K = \\frac{ 1 } { \\frac{ dx_{l+1} } { \\lambda_{l+1} } + \\frac{ dx_{l} }{ \\lambda_{l} } } $  "
    ]
   },
   {
@@ -62,15 +119,169 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def vapourTransfer_pressure( ldp, dpv, dx2 ):\n",
-    "    return ldp * dpv /dx2"
+    "def transmittance( val_mns, val_pls, len_mns, len_pls ):\n",
+    "    return 1.0 / ( len_mns / val_mns + len_pls / val_pls )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def heat_conduction_v2( lamL1, lamL, tempL1, tempL, dxL1, dxL ):\n",
+    "    K = transmittance( val_mns = lamL, val_pls = lamL1, len_mns = dxL, len_pls = dxL1 )\n",
+    "    return - K * ( tempL1 - tempL )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "18.181818181818183"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "#　使用例\n",
+    "heat_conduction_v2( 0.1, 1.0, 20.0, 22.0, 0.01, 0.01 )"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 液相水分流（水分化学ポテンシャル勾配・固体内）  \n",
+    "#### 差分化その3：$\\dot q = -\\lambda_{ave.}\\frac{\\Delta T}{\\Delta x2}$  \n",
+    "$\\Delta T$：質点間の温度差[K]  \n",
+    "$\\Delta x2$：質点間の距離[m]  \n",
+    "平均の熱伝導率、温度差などをあらかじめ計算している場合はこちらを用いる。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def heat_conduction_v3( lam, dtemp, dx2 ):\n",
+    "    return - lam * dtemp / dx2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "18.18"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# 使用例  \n",
+    "heat_conduction_v3( 9.090, -2.0, 1.0 )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 熱伝達  \n",
+    "定義：$\\dot q = \\alpha(T_{air} - T_{wall})$  \n",
+    "空気に接する壁表面には空気の熱伝達層が存在すると考えた場合の熱流。空気から壁表面への熱流を正とした。  \n",
+    "$\\dot q$：単位時間当たりの熱流量の密度[W/m2]  \n",
+    "$\\alpha$：熱伝達率[W/m2K]  \n",
+    "$T_{air}$：空気の絶対温度[K]  \n",
+    "$T_{wall}$：壁表面の絶対温度[K]  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def heat_transfer( alpha, temp_air, temp_wall ):\n",
+    "    return alpha * ( temp_air - temp_wall )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "46.5"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# 使用例\n",
+    "heat_transfer( 9.3, 20.0, 15.0 )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 水蒸気移動  \n",
+    "元原理：Fickの拡散法則"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 水蒸気移動（水蒸気圧勾配・固体内）  \n",
+    "定義：$J_v = -\\lambda^{'}_{p}\\nabla・P_v$  \n",
+    "$J_v$：気相水分流量[kg/m2s]  \n",
+    "$\\lambda^{'}_{p}$：水蒸気圧勾配に関する気相水分伝導率[kg/msPa]  \n",
+    "$P_v$：水蒸気圧[Pa]  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def vapourTransfer_pressure( ldp, dpv, dx2 ):\n",
+    "    return - ldp * dpv /dx2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 液水移動  \n",
+    "原理：ダルシー則"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 液水移動（水分化学ポテンシャル勾配・固体内）  \n",
     "定義：$J_l = -\\lambda^{'}_{\\mu_l}(\\nabla・\\mu - n_x g)$    \n",
     "$J_l$：液相水分流量[kg/m2s]  \n",
     "$\\lambda^{'}_{\\mu l}$：水分化学ポテンシャル勾配に関する液相水分伝導率[kg/ms(J/kg)]  \n",
@@ -80,12 +291,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
     "def liquidTransfer_potential( ldml, dmiu, dx2, nx ):\n",
-    "    return ldml * ( dmiu / dx2 - nx * grav() )"
+    "    return - ldml * ( dmiu / dx2 - nx * grav() )"
    ]
   },
   {


### PR DESCRIPTION
熱流の計算式をv1からv3の方法で書いてみました。
建築学会大会のときにも少しお話ししましたが、v1の方法（物性値に長さの比重をかけて調和平均をとる方法）は確かに熱伝導率が大きく異なる時に熱伝導率の高い材料に引っ張られるため、正確性に欠ける可能性がありますね。
基本はv2、もしくはv3で書く方が良いと思いました。またメインプログラム上で実際にfluxを計算するまでの手順を書いてみました。（10セル目まで）